### PR TITLE
resolves #15

### DIFF
--- a/spec/methods_spec.js
+++ b/spec/methods_spec.js
@@ -21,29 +21,30 @@ describe('jQuery Methods', function() {
   it('#showDolphin makes the dolphin image visible in the browser', function() {
     expect($("#hidden")).toBeHidden();
     showDolphin();
-    expect($("#hidden").attr('style')).toBe("display: inline;");
+    expect($("#hidden").attr('style')).toContain("display: inline;");
   });
 
   it('#hideImage hides the pie face gif', function() {
     hideImage();
-    expect($('img[alt="pie in face"]').attr('style')).toBe("display: none;");
+    expect($('img[alt="pie in face"]').attr('style')).toContain("display: none;" );
   });
 
 
   it('#fadeIt shows the list of favorite snacks', function() {
     fadeIt();
-    expect($('#favorite-snacks').attr('style')).toBe("display: block; opacity: 0;");
+    expect($('#favorite-snacks').attr('style')).toContain("display: block; opacity: 0;");
   });
 
   it('#fadeItOut hides the second paragraph', function() {
     fadeItOut();
-    expect($('p:first-child + p').attr("style")).toBe("display: none;");
+    expect($('p:first-child + p').attr("style")).toContain("display: none;");
   });
 
 
   it('#findItByClass returns true for the a tag and false for every other tag', function() {
     expect(findItByClass('a')).toBe(true);
     expect(findItByClass('p')).toBe(false);
+
   });
 
   it('#formValue returns the value of the last input tag', function() {


### PR DESCRIPTION
@aturkewi 

A few students were having issues with the inline styles having an extra space at the end of the style but the styles were otherwise identical. They were having to change the spec to accommodate the space in order to move on. This change to the specs should allow both `"display: inline;"` and `"display: inline; "` to pass.